### PR TITLE
90 string locations

### DIFF
--- a/src/board.py
+++ b/src/board.py
@@ -60,7 +60,8 @@ class Board:
 
     def move(self, from_location, to_location):
         """Move a player from one location and to another."""
-
+        if type(from_location) is not str or type(to_location) is not str:
+            raise TypeError('to_location and from_location should be type str')
         if not self._locations[from_location].remove_occupant():
             #raise ValueError()
             return

--- a/src/move.py
+++ b/src/move.py
@@ -2,12 +2,16 @@
 
 Contains the piece to move, and the destination for it to be moved to.
 """
+from src.location import Location
 
 
 class Move:
     """The piece to move, and the destination for it to be moved to."""
 
     def __init__(self, character, destination):
+        if type(destination) is not str:
+            raise TypeError('destination should be type str, not Location')
+
         """Initialize."""
         self._character = character
         self._destination = destination

--- a/src/movementengine.py
+++ b/src/movementengine.py
@@ -32,7 +32,7 @@ class MovementEngine:
         # Get player's current location
         player_list = PlayerList()
         player = player_list.get_player(move.get_charcter_id())
-        from_location = player.get_current_location()
+        from_location = self._board.get_location(player.get_current_location())
 
         # Get destination location from board
         destination = self._board.get_location(move.get_destination())
@@ -53,8 +53,7 @@ class MovementEngine:
         from_location = player.get_current_location()
 
         # Execute move on board and update player location
-        self._board.move(from_location._key, move.get_destination())
-        dest_location = self._board.get_location(move.get_destination())
-        player.set_location(dest_location)
+        self._board.move(from_location, move.get_destination())
+        player.set_location(move.get_destination())
 
         return

--- a/src/player.py
+++ b/src/player.py
@@ -67,7 +67,9 @@ class Player(object):
         # print('get_status method in Player class')
         return self._status
 
-    def set_location(self, location: Location):
+    def set_location(self, location: str):
+        if type(location) is not str:
+            raise TypeError('set_location expects a string index of a location')
         """Sets the Location to where the Player is on the gameboard"""
         # print('set_location method in Player class')
         if self._previous_location is None:
@@ -76,11 +78,11 @@ class Player(object):
             self._previous_location = self._current_location
         self._current_location = location
 
-    def get_current_location(self) -> Location:
+    def get_current_location(self) -> str:
         """Return the Player's current Location"""
         return self._current_location
 
-    def get_previous_location(self) -> Location:
+    def get_previous_location(self) -> str:
         """Return the Player's previous Location"""
         return self._previous_location
 

--- a/src/playerlist.py
+++ b/src/playerlist.py
@@ -69,7 +69,7 @@ class PlayerList:
     def get_player(self, uuid: str) -> Player:
         """Accepts a UUID and returns the corresponding Player object"""
         for player in self._player_list:
-            if uuid == player.get_uuid():
+            if uuid == player.get_card_id():
                 player_index = self._player_list.index(player)
                 return self._player_list[player_index]
         return None

--- a/src/playerlist.py
+++ b/src/playerlist.py
@@ -66,10 +66,10 @@ class PlayerList:
         """Returns a List of all Players"""
         return self._player_list
 
-    def get_player(self, uuid: str) -> Player:
+    def get_player(self, card_id: str) -> Player:
         """Accepts a UUID and returns the corresponding Player object"""
         for player in self._player_list:
-            if uuid == player.get_card_id():
+            if card_id == player.get_card_id():
                 player_index = self._player_list.index(player)
                 return self._player_list[player_index]
         return None

--- a/test/unit/test_movementengine.py
+++ b/test/unit/test_movementengine.py
@@ -37,8 +37,8 @@ _6x2 = me._board.get_location("6x2")
 
 def test_detect_illegal_move():
     """Ask the Movement Engine to check move to non-neighbor."""
-    MIS_SCA.set_location(_4x0)
-    COL_MUS.set_location(_6x2)
+    MIS_SCA.set_location(_4x0._key)
+    COL_MUS.set_location(_6x2._key)
 
     # Sanity check - characters are in locations
     assert me._board.get_location("4x0").get_occupant_count() == 1

--- a/test/unit/test_movementengine.py
+++ b/test/unit/test_movementengine.py
@@ -44,7 +44,7 @@ def test_detect_illegal_move():
     assert me._board.get_location("4x0").get_occupant_count() == 1
     assert me._board.get_location("6x2").get_occupant_count() == 1
 
-    move = Move(MIS_SCA.get_token(), _5x1._key)
+    move = Move(MIS_SCA.get_card_id(), _5x1._key)
 
     assert not me.is_valid_move(move)
 
@@ -52,7 +52,7 @@ def test_detect_illegal_move():
 def test_detect_move_to_occupied_passage():
     """Ask the Movement Engine to check a move to an occupied passage."""
     # Move character to passage blocking Miss Scarlet
-    move = Move(COL_MUS.get_token(), _4x1._key)
+    move = Move(COL_MUS.get_card_id(), _4x1._key)
     me.do_move(move)
 
     # Sanity check - characters are in locations
@@ -60,14 +60,14 @@ def test_detect_move_to_occupied_passage():
     assert me._board.get_location("4x0").get_occupant_count() == 1
 
     # Check validity of moving Miss Scarlett to newly occupied passage
-    move2 = Move(MIS_SCA.get_token(), _4x1._key)
+    move2 = Move(MIS_SCA.get_card_id(), _4x1._key)
     assert not me.is_valid_move(move2)
 
 
 def test_detect_move_to_unoccupied_passage():
     """Ask the Movement Engine to check a valid move."""
     # Move character out of Miss Scarlet's way
-    move = Move(COL_MUS.get_token(), _5x1._key)
+    move = Move(COL_MUS.get_card_id(), _5x1._key)
     me.do_move(move)
 
     # Sanity check - characters are in locations
@@ -75,14 +75,14 @@ def test_detect_move_to_unoccupied_passage():
     assert me._board.get_location("4x0").get_occupant_count() == 1
 
     # Check validity of moving Miss Scarlett to newly unoccupied passage
-    move2 = Move(MIS_SCA.get_token(), _4x1._key)
+    move2 = Move(MIS_SCA.get_card_id(), _4x1._key)
     assert me.is_valid_move(move2)
 
 
 def test_detect_move_to_occupied_room():
     """Ask the Movement Engine to check validity of move to occupied room."""
     # Move Miss Scarlet out of her starting point
-    move = Move(MIS_SCA.get_token(), _4x1._key)
+    move = Move(MIS_SCA.get_card_id(), _4x1._key)
     me.do_move(move)
 
     # Sanity check - characters are in locations
@@ -90,14 +90,14 @@ def test_detect_move_to_occupied_room():
     assert me._board.get_location("5x1").get_occupant_count() == 1
 
     # Check validity of moving Miss Scarlet to Lounge
-    move2 = Move(MIS_SCA.get_token(), _5x1._key)
+    move2 = Move(MIS_SCA.get_card_id(), _5x1._key)
     assert me.is_valid_move(move2)
 
 
 def test_detect_move_to_unoccupied_room():
     """Ask the Movemetn Engine to check validity of move to empty room."""
     # Move player out of Lounge
-    move = Move(COL_MUS.get_token(), _3x1._key)
+    move = Move(COL_MUS.get_card_id(), _3x1._key)
     me.do_move(move)
 
     # Sanity check - characters are in locations
@@ -105,7 +105,7 @@ def test_detect_move_to_unoccupied_room():
     assert me._board.get_location("3x1").get_occupant_count() == 1
 
     # Check validity of moving Miss Scarlet to Lounge
-    move2 = Move(MIS_SCA.get_token(), _5x1._key)
+    move2 = Move(MIS_SCA.get_card_id(), _5x1._key)
     assert me.is_valid_move(move2)
     me.do_move(move2)
 
@@ -113,7 +113,7 @@ def test_detect_move_to_unoccupied_room():
 def test_execute_non_neighbor_move():
     """Ensure MovementEngine.do_move() works when someone is suggested."""
     hall_occ = me._board.get_location("3x1").get_occupant_count()
-    move = Move(MIS_SCA.get_token(), _3x1._key)
+    move = Move(MIS_SCA.get_card_id(), _3x1._key)
 
     assert not me.is_valid_move(move)
 

--- a/test/unit/test_player.py
+++ b/test/unit/test_player.py
@@ -52,13 +52,13 @@ def test_set_and_get_status():
 def test_set_and_get_locations():
     assert test_player.get_current_location() is None
     assert test_player.get_previous_location() is None
-    test_player.set_location(test_location1)
-    assert test_player.get_current_location() == test_location1
-    assert test_player.get_previous_location() == test_location1
-    assert type(test_player.get_current_location()) is Location
-    test_player.set_location(test_location2)
-    assert test_player.get_current_location() == test_location2
-    assert test_player.get_previous_location() == test_location1
+    test_player.set_location(test_location1._key)
+    assert test_player.get_current_location() == test_location1._key
+    assert test_player.get_previous_location() == test_location1._key
+    assert type(test_player.get_current_location()) is str
+    test_player.set_location(test_location2._key)
+    assert test_player.get_current_location() == test_location2._key
+    assert test_player.get_previous_location() == test_location1._key
 
 
 def test_set_and_get_card_id():

--- a/test/unit/test_playerlist.py
+++ b/test/unit/test_playerlist.py
@@ -107,5 +107,5 @@ def test_get_player():
         assert True
     else:
         assert False
-    assert test_plist1.get_player('TEST UUID') == test_player3
-    assert type(test_plist1.get_player('TEST UUID')) is Player
+    assert test_plist1.get_player("TEST333ID") == test_player3
+    assert type(test_plist1.get_player('TEST333ID')) is Player


### PR DESCRIPTION
This merge does the following:
Close out #85.  Fix movementengine tests so that all pass. This is accomplished by changing the PlayerList function get_player() to fetch a player by card_id instead of UUID.

This also fixes other bugs associated with Locations (ticket #90). Throughout the implementation, different things were being used to represent a Location, sometimes a class Location, sometimes a string referencing the index of a Location. This changes all references outside of Board to be strings.

